### PR TITLE
Avoid warning from esmith::util::isValidIP()

### DIFF
--- a/lib/perl/esmith/util/network.pm
+++ b/lib/perl/esmith/util/network.pm
@@ -130,6 +130,7 @@ my @goodIPs = qw(1.2.3.4
 sub isValidIP($)
 {
     my ($string) = @_;
+    return unless defined ipv4_chkip($string);
     return $string eq ipv4_chkip($string);
 }
 


### PR DESCRIPTION
The function doesn't accept empty value ('')

PLease can you accept my PR, my code is broken with the function 'isValidIP'