### PR TITLE
Add db setjson implementation

### DIFF
--- a/root/sbin/e-smith/db
+++ b/root/sbin/e-smith/db
@@ -65,6 +65,12 @@ my %commands = (
 		    			. "[prop1 val1] [prop2 val2] ...",
 		},
 
+        'setjson'
+            =>  {
+                    'function'  =>      \&DB_set_json,
+                    'usage'     =>      "$0 dbfile setjson [jsondata|-]",
+                },
+
 	'setdefault'
 	    =>	{
 		    'function'	=>	\&DB_set_default,
@@ -138,6 +144,7 @@ my $usage = "usage:
     $commands{'get'}{'usage'}
     $commands{'getjson'}{'usage'}
     $commands{'set'}{'usage'}
+    $commands{'setjson'}{'usage'}
     $commands{'setdefault'}{'usage'}
     $commands{'delete'}{'usage'}
     $commands{'printtype'}{'usage'}
@@ -248,6 +255,27 @@ sub DB_set
     $db->set($key, $type) or exit 1;
 
     &DB_setprop($key, @_) if scalar @_;
+}
+
+sub DB_set_json
+{
+    my $data = shift;
+    die "$commands{'setjson'}{'usage'}\n" unless $data;
+
+    if($data eq '-') {
+        # slurp STDIN using the do-local Perl idiom:
+        $data = do { local $/; <STDIN> }
+    }
+
+    my $object = from_json($data);
+    if(ref($object) eq 'HASH') {
+        # wrap the record inside an array:
+        $object = [$object];
+    }
+
+    foreach (@{$object}) {
+        $db->set($_->{'name'}, $_->{'type'}, $_->{'props'});
+    }
 }
 
 sub DB_set_default


### PR DESCRIPTION
The dual operation of getjson. We were missing it!

The ``setjson`` command allows importing the output of ``getjson``. It reads data from the command line argument or from STDIN, if "-" is specified as argument. Sample usages:

    db configuration getjson sysconfig > sysconfig.json ; db copyconf "$(<sysconfig.json)"
    db configuration getjson sysconfig | db copyconf setjson -
    db copyconf setjson '{"props":{"Version":"7.3.1611","Release":"Final","Copyright":"","DefaultLanguage":"en_US.utf8","ProductName":"NethServer"},"name":"sysconfig","type":"configuration"}'
    db restored setjson - <dump.json