### PR TITLE
Do not fail when a service unit is masked

### DIFF
--- a/lib/perl/NethServer/Service.pm
+++ b/lib/perl/NethServer/Service.pm
@@ -229,6 +229,22 @@ sub is_running
     return system('systemctl', '-q', 'is-active', $self->{'serviceName'}) == 0;
 }
 
+=head2 ->is_masked
+
+Check if the service unit is in "masked" state. See systemctl manpage.
+
+=cut
+sub is_masked
+{
+    my $self = shift;
+    my $unitName = $self->{'serviceName'};
+    my $output = qx(systemctl show --property=LoadState $unitName);
+    if($output =~ /^LoadState=masked$/) {
+        return 1;
+    }
+    return 0;
+}
+
 =head2 ->adjust
 
 Adjust the service startup state and running state according to its

--- a/root/etc/e-smith/events/actions/adjust-services
+++ b/root/etc/e-smith/events/actions/adjust-services
@@ -86,7 +86,7 @@ foreach my $service (@services)
     foreach (@actions) {
 	warn "[INFO] service $service $_\n";
 	$tracker->set_task_progress($tasks{$service}, $progress, $_);
-	if($s->can($_) && ! $s->$_() ) {
+	if($s->can($_) && ! $s->$_() && ! $s->is_masked()) {
 	    $errorMessage .= sprintf("%s service %s failed!\n", $_, $service);
 	    $errors++;	
 	    $failed = 1;


### PR DESCRIPTION
The adjust-services action must check if a unit is masked before
returning an error condition.

NethServer/dev#5314