### PR TITLE
Support is_masked state in runlevel-adjust action

### DIFF
--- a/lib/perl/NethServer/Service.pm
+++ b/lib/perl/NethServer/Service.pm
@@ -265,7 +265,7 @@ sub adjust
     my $action = shift;
     my $errors = 0;
 
-    if($self->is_configured()) {
+    if($self->is_configured() && ! $self->is_masked() ) {
 	my $staticState = $self->is_enabled() && $self->is_owned();
 	system(sprintf('systemctl -q %s "%s" 2>/dev/null', ($staticState ? 'enable' : 'disable'), $self->{'serviceName'}));
 	if($staticState != $self->is_running()) {

--- a/root/etc/e-smith/events/actions/adjust-services
+++ b/root/etc/e-smith/events/actions/adjust-services
@@ -73,7 +73,7 @@ foreach my $service (@services)
     } elsif ($action eq 'stop') {
 	$successMessage = sprintf("%s %s and has been stopped\n", $service, get_reason($s));
 
-    } elsif ($s->is_configured() && $s->is_enabled() && $s->is_owned()) {
+    } elsif ($s->is_configured() && $s->is_enabled() && $s->is_owned() && ! $s->is_masked() ) {
 	@actions = get_actions($service);
 	$successMessage = sprintf("%s %s", $service, join(", ", @actions));
 
@@ -86,7 +86,7 @@ foreach my $service (@services)
     foreach (@actions) {
 	warn "[INFO] service $service $_\n";
 	$tracker->set_task_progress($tasks{$service}, $progress, $_);
-	if($s->can($_) && ! $s->$_() && ! $s->is_masked()) {
+	if($s->can($_) && ! $s->$_() ) {
 	    $errorMessage .= sprintf("%s service %s failed!\n", $_, $service);
 	    $errors++;	
 	    $failed = 1;
@@ -119,6 +119,8 @@ sub get_reason
 	$r = "is not configured";
     } elsif( ! $s->is_owned()) {
 	$r = "is not owned by any package";
+    } elsif( $s->is_masked()) {
+	$r = "is masked";
     } elsif( ! $s->is_enabled()) {
 	$r = "is disabled";
     } else {

--- a/root/etc/e-smith/events/actions/adjust-services
+++ b/root/etc/e-smith/events/actions/adjust-services
@@ -71,20 +71,24 @@ foreach my $service (@services)
 	} get_actions($service);
 
     } elsif ($action eq 'stop') {
-	$successMessage = sprintf("%s %s and has been stopped\n", $service, get_reason($s));
+	$successMessage = sprintf("service %s %s and has been stopped\n", $service, get_reason($s));
 
     } elsif ($s->is_configured() && $s->is_enabled() && $s->is_owned() && ! $s->is_masked() ) {
 	@actions = get_actions($service);
-	$successMessage = sprintf("%s %s", $service, join(", ", @actions));
+	$successMessage = sprintf("service %s %s", $service, join(", ", @actions));
 
     } else {
-	warn sprintf("[INFO] %s %s: skipped\n", $service, get_reason($s));
+	warn sprintf("[INFO] service %s %s: skipped\n", $service, get_reason($s));
 
+    }
+
+    chomp($successMessage);
+    if($successMessage) {
+        warn "[INFO] " . $successMessage . "\n";
     }
 
     my $progress = 0.1;
     foreach (@actions) {
-	warn "[INFO] service $service $_\n";
 	$tracker->set_task_progress($tasks{$service}, $progress, $_);
 	if($s->can($_) && ! $s->$_() ) {
 	    $errorMessage .= sprintf("%s service %s failed!\n", $_, $service);
@@ -95,11 +99,8 @@ foreach my $service (@services)
     }	    
 
     chomp($errorMessage);
-
-    if($failed) {
+    if($failed && $errorMessage) {
 	warn "[WARNING] " . $errorMessage . "\n";
-    } else {
-	warn "[INFO] " . $successMessage . "\n";
     }
 
     $tracker->set_task_done($tasks{$service}, ($failed ? $errorMessage : $successMessage), $failed);


### PR DESCRIPTION
In commit b12e6c8 adjust-services has been modified to check the ``is_masked()`` condition. However runlevel-adjust was still lacking support for masked units.

The previous ``adjust()`` method semantics was "change the service runtime status to reflect the configured/static status".

This PR extends the ``adjust()`` semantics to consider also the ``is_masked()`` state. It skips any action on masked units. This makes ``runlevel-adjust`` implicitly aware of masked units.

A small log output refactor is also performed to avoid empty log lines when action is skipped.

NethServer/dev#5343