### PR TITLE
Fix DELETE=1 exit code

### DIFF
--- a/lib/perl/esmith/templates.pm
+++ b/lib/perl/esmith/templates.pm
@@ -444,7 +444,7 @@ sub processTemplate {
         if ($p{'DELETE'})
         {
             unlink "$outputfile";
-            return;
+            return 1;
         }
 
         # use POSIX::open to set permissions on create


### PR DESCRIPTION
The template.metadata directive exits with a bad status (false). Fix the
returned value to avoid wrong template expansion error code.

NethServer/dev#5437
https://github.com/NethServer/docs/pull/298