### PR TITLE
correct pod format

### DIFF
--- a/lib/perl/esmith/DB.pm
+++ b/lib/perl/esmith/DB.pm
@@ -404,6 +404,8 @@ call, which is what this is going to do. :)
 
 This method returns a list of keys to the records in the db. It does not sort.
 
+=back
+
 =cut
 
 sub keys
@@ -694,7 +696,7 @@ sub error
     return $Error;
 }
 
-=back
+=pod
 
 =head1 AUTHOR
 


### PR DESCRIPTION
`perldoc -U esmith::DB` warns about:
```
POD ERRORS
    Hey! The above document had some coding errors, which are explained
    below:

    Around line 417:
        You forgot a '=back' before '=head2'

    Around line 697:
        =back without =over
```